### PR TITLE
DD-336 7.x-1.x fix client term block placement

### DIFF
--- a/dennis_client.install
+++ b/dennis_client.install
@@ -275,3 +275,11 @@ function dennis_client_update_7103() {
   // Revert this Feature.
   features_revert(array('dennis_client' => array('field')));
 }
+
+/**
+ * Placing content_partnerships_client_term block in preface_top by default.
+ */
+function dennis_client_update_7104() {
+  // Re-save the contexts
+  _dennis_client_create_contexts();
+}

--- a/dennis_client.install
+++ b/dennis_client.install
@@ -184,8 +184,8 @@ function _dennis_client_default_contexts() {
         'dennis_client-content_partnerships_client_term' => array(
           'module' => 'dennis_client',
           'delta' => 'content_partnerships_client_term',
-          'region' => 'content_top',
-          'weight' => '-10',
+          'region' => 'preface_top',
+          'weight' => '100',
         ),
       ),
     ),


### PR DESCRIPTION
Confirmed with @KidUnknown that the `content_partnerships_client_term` block should be place in `preface_top` by default.